### PR TITLE
Move texture anisotropy check to SetInfo

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -1,6 +1,5 @@
 using Ryujinx.Graphics.GAL;
 using System;
-using System.Numerics;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -9,8 +8,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class Sampler : IDisposable
     {
-        private const int MinLevelsForAnisotropic = 5;
-
         /// <summary>
         /// Host sampler object.
         /// </summary>
@@ -96,26 +93,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>A host sampler</returns>
         public ISampler GetHostSampler(Texture texture)
         {
-            return _anisoSampler != null && AllowForceAnisotropy(texture) ? _anisoSampler : _hostSampler;
-        }
-
-        /// <summary>
-        /// Determine if the given texture can have anisotropic filtering forced.
-        /// Filtered textures that we might want to force anisotropy on should have a lot of mip levels.
-        /// </summary>
-        /// <param name="texture">The texture</param>
-        /// <returns>True if anisotropic filtering can be forced, false otherwise</returns>
-        private static bool AllowForceAnisotropy(Texture texture)
-        {
-            if (texture == null || !(texture.Target == Target.Texture2D || texture.Target == Target.Texture2DArray))
-            {
-                return false;
-            }
-
-            int maxSize = Math.Max(texture.Info.Width, texture.Info.Height);
-            int maxLevels = BitOperations.Log2((uint)maxSize) + 1;
-
-            return texture.Info.Levels >= Math.Min(MinLevelsForAnisotropic, maxLevels);
+            return _anisoSampler != null && texture?.CanForceAnisotropy == true ? _anisoSampler : _hostSampler;
         }
 
         /// <summary>


### PR DESCRIPTION
Rather than calculating this for every sampler, this PR calculates if a texture can force anisotropy when its info is set, and exposes the value via a public boolean.

This should help texture/sampler heavy games when anisotropic filtering is not Auto, like UE4 ones (or so i hear?). There is another cost where samplers are created twice when anisotropic filtering is enabled, but I'm not sure how relevant this one is.